### PR TITLE
Move parse to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "main": "index.js",
   "version": "0.2.0",
   "dependencies": {
-    "gm": "~1.21.1",
-    "parse": "^1.3.5"
+    "gm": "~1.21.1"
   },
   "devDependencies": {
     "codecov": "^1.0.1",
@@ -31,5 +30,8 @@
     "parse",
     "image",
     "module"
-  ]
+  ],
+  "peerDependencies": {
+    "parse": "^1.3.5"
+  }
 }


### PR DESCRIPTION
In my unit tests I am using parse-mockdb.  If there are multiple installs of parse in the dependency tree, mockdb gets confused.  Making parse a peer dependency (which I think is accurate) cures the problem.
